### PR TITLE
chore: Text Field configs were added

### DIFF
--- a/components/config_scheme.json
+++ b/components/config_scheme.json
@@ -1,0 +1,129 @@
+{
+    "view": {
+        "[view_variation#1]": {
+            "props": {
+                "[componentProp#1]": {
+                    "type": [
+                        "color",
+                        "dimension",
+                        "gradient",
+                        "typography",
+                        "shape",
+                        "component_style",
+                        "value"
+                    ],
+                    "valueProp#1": "зависит от type",
+                    "valueProp#2": "зависит от type",
+                    "и т.д.": "зависит от type"
+                }
+            }
+        }
+    },
+    "props": {
+        "[invariant_componentProp#1]": {
+            "type": [
+                "color",
+                "dimension",
+                "gradient",
+                "typography",
+                "shape",
+                "component_style",
+                "value"
+            ],
+            "valueProp#1": "зависит от type",
+            "valueProp#2": "зависит от type",
+            "и т.д.": "зависит от type"
+        }
+    },
+    "variations": [
+        {
+            "id": "variation#1",
+            "parent": "parentId",
+            "view": {
+                "[override_view_variation#1]": {
+                    "[componentProp#1]": {
+                        "type": [
+                            "Тип не нужен",
+                            "color",
+                            "dimension",
+                            "gradient",
+                            "typography",
+                            "shape",
+                            "component_style",
+                            "value"
+                        ],
+                        "valueProp#1": "зависит от type",
+                        "valueProp#2": "зависит от type",
+                        "и т.д.": "зависит от type"
+                    }
+                }
+            },
+            "props": {
+                "componentProp#1": {
+                    "type": [
+                        "Тип не нужен",
+                        "color",
+                        "dimension",
+                        "gradient",
+                        "typography",
+                        "shape",
+                        "component_style",
+                        "value"
+                    ],
+                    "valueProp#1": "зависит от type",
+                    "valueProp#2": "зависит от type",
+                    "и т.д.": "зависит от type"
+                },
+                "colorProp": {
+                    "type": "color",
+                    "default": "#token_value",
+                    "states": [
+                        {
+                            "state": [
+                                "pressed",
+                                "focused",
+                                "hovered"
+                            ],
+                            "value": "#token_value"
+                        }
+                    ]
+                },
+                "gradientProp": {
+                    "type": "gradient",
+                    "default": "#token_value",
+                    "states": [
+                        {
+                            "state": [
+                                "pressed",
+                                "focused",
+                                "hovered"
+                            ],
+                            "value": "#token_value"
+                        }
+                    ]
+                },
+                "shapeProp": {
+                    "type": "shape",
+                    "value": "#token_value",
+                    "adjustment": 0
+                },
+                "componentStyleProp": {
+                    "type": "component_style",
+                    "value": "#style_name"
+                },
+                "dimensionProp": {
+                    "type": "dimension",
+                    "value": 1.0
+                },
+                "typographyProp": {
+                    "type": "typography",
+                    "value": "#token_value"
+                },
+                "valueProp": {
+                    "type": "value",
+                    "value": "some_value"
+                }
+            }
+        }
+    ]
+}

--- a/components/sdds_serv/text_field_clear_config.json
+++ b/components/sdds_serv/text_field_clear_config.json
@@ -1,0 +1,1392 @@
+{
+  "view": {
+    "default": {
+      "props": {
+        "valueColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "captionColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "placeholderColor": {
+          "type": "color",
+          "default": "text.default.secondary",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.tertiary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.tertiary"
+            }
+          ]
+        },
+        "dividerColor": {
+          "type": "color",
+          "default": "surface.default.transparent-tertiary",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "surface.default.accent"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "surface.default.accent"
+            }
+          ]
+        },
+        "startContentColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        }
+      }
+    },
+    "success": {
+      "props": {
+        "valueColor": {
+          "type": "color",
+          "default": "text.default.positive",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.primary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.primary"
+            }
+          ]
+        },
+        "placeholderColor": {
+          "type": "color",
+          "default": "text.default.positive",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.tertiary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.tertiary"
+            }
+          ]
+        },
+        "captionColor": {
+          "type": "color",
+          "default": "text.default.positive",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        },
+        "dividerColor": {
+          "type": "color",
+          "default": "surface.default.positive",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "surface.default.accent"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "surface.default.accent"
+            }
+          ]
+        },
+        "startContentColor": {
+          "type": "color",
+          "default": "text.default.positive",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        }
+      }
+    },
+    "warning": {
+      "props": {
+        "valueColor": {
+          "type": "color",
+          "default": "text.default.warning",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.primary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.primary"
+            }
+          ]
+        },
+        "placeholderColor": {
+          "type": "color",
+          "default": "text.default.warning",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.tertiary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.tertiary"
+            }
+          ]
+        },
+        "captionColor": {
+          "type": "color",
+          "default": "text.default.warning",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        },
+        "dividerColor": {
+          "type": "color",
+          "default": "surface.default.warning",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "surface.default.accent"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "surface.default.accent"
+            }
+          ]
+        },
+        "startContentColor": {
+          "type": "color",
+          "default": "text.default.warning",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        }
+      }
+    },
+    "error": {
+      "props": {
+        "valueColor": {
+          "type": "color",
+          "default": "text.default.negative",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.primary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.primary"
+            }
+          ]
+        },
+        "placeholderColor": {
+          "type": "color",
+          "default": "text.default.negative",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.tertiary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.tertiary"
+            }
+          ]
+        },
+        "captionColor": {
+          "type": "color",
+          "default": "text.default.negative",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        },
+        "dividerColor": {
+          "type": "color",
+          "default": "surface.default.negative",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "surface.default.accent"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "surface.default.accent"
+            }
+          ]
+        },
+        "startContentColor": {
+          "type": "color",
+          "default": "text.default.negative",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "props": {
+    "disableAlpha": 0.4,
+    "enableAlpha": 1.0,
+    "helperTextPlacement": {
+      "type": "value",
+      "value": "outer"
+    },
+    "captionStyle": {
+      "type": "typography",
+      "value": "body.xs.normal"
+    },
+    "counterStyle": {
+      "type": "typography",
+      "value": "body.xs.normal"
+    },
+    "chipGroupStyle": {
+      "type": "component_style",
+      "value": "chip-group.dense"
+    },
+    "optionalPadding": {
+      "type": "dimension",
+      "value": 4.0
+    },
+    "helperTextPadding": {
+      "type": "dimension",
+      "value": 4.0
+    },
+    "chipsPadding": {
+      "type": "dimension",
+      "value": 6.0
+    },
+    "boxPaddingStart": {
+      "type": "dimension",
+      "value": 0.0
+    },
+    "boxPaddingEnd": {
+      "type": "dimension",
+      "value": 0.0
+    },
+    "valueColorReadOnly": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "captionColorReadOnly": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "endContentColor": {
+      "type": "color",
+      "default": "text.default.secondary",
+      "states": [
+        {
+          "state": [
+            "pressed"
+          ],
+          "value": "text.default.secondary-active"
+        },
+        {
+          "state": [
+            "hovered"
+          ],
+          "value": "text.default.secondary-hover"
+        }
+      ]
+    },
+    "optionalColor": {
+      "type": "color",
+      "default": "text.default.tertiary"
+    },
+    "counterColor": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "placeholderColorReadOnly": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "indicatorColor": {
+      "type": "color",
+      "default": "surface.default.negative"
+    },
+    "cursorColor": {
+      "type": "color",
+      "default": "text.default.accent"
+    }
+  },
+  "variations": [
+    {
+      "id": "xs",
+      "parent": null,
+      "props": {
+        "labelPlacement": {
+          "type": "value",
+          "value": "none"
+        },
+        "chipStyle": {
+          "type": "component_style",
+          "value": "embedded-chip.xs.secondary"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "startContentPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "endContentPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "boxMinHeight": {
+          "type": "dimension",
+          "value": 32.0
+        },
+        "alignmentMinHeight": {
+          "type": "dimension",
+          "value": 32.0
+        },
+        "startContentSize": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "endContentSize": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "valueStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "placeholderStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "fieldType": {
+          "type": "value",
+          "value": "optional"
+        }
+      }
+    },
+    {
+      "id": "xs.required-start",
+      "parent": "xs",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 13.0
+        }
+      }
+    },
+    {
+      "id": "xs.required-end",
+      "parent": "xs",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 13.0
+        }
+      }
+    },
+    {
+      "id": "xs.outer-label",
+      "parent": "xs",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "outer"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 2.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        }
+      }
+    },
+    {
+      "id": "xs.outer-label.required-start",
+      "parent": "xs.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 4.0
+        }
+      }
+    },
+    {
+      "id": "xs.outer-label.required-end",
+      "parent": "xs.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 2.0
+        }
+      }
+    },
+    {
+      "id": "s",
+      "parent": null,
+      "props": {
+        "labelPlacement": {
+          "type": "value",
+          "value": "none"
+        },
+        "chipStyle": {
+          "type": "component_style",
+          "value": "embedded-chip.s.secondary"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "startContentPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "endContentPadding": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "boxMinHeight": {
+          "type": "dimension",
+          "value": 40.0
+        },
+        "alignmentMinHeight": {
+          "type": "dimension",
+          "value": 40.0
+        },
+        "startContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "endContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "valueStyle": {
+          "type": "typography",
+          "value": "body.s.normal"
+        },
+        "placeholderStyle": {
+          "type": "typography",
+          "value": "body.s.normal"
+        },
+        "fieldType": {
+          "type": "value",
+          "value": "optional"
+        }
+      }
+    },
+    {
+      "id": "s.required-start",
+      "parent": "s",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 17.0
+        }
+      }
+    },
+    {
+      "id": "s.required-end",
+      "parent": "s",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 17.0
+        }
+      }
+    },
+    {
+      "id": "s.outer-label",
+      "parent": "s",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "outer"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.s.normal"
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.s.normal"
+        }
+      }
+    },
+    {
+      "id": "s.outer-label.required-start",
+      "parent": "s.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 6.0
+        }
+      }
+    },
+    {
+      "id": "s.outer-label.required-end",
+      "parent": "s.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 4.0
+        }
+      }
+    },
+    {
+      "id": "s.inner-label",
+      "parent": "s",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "inner"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 0.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        }
+      }
+    },
+    {
+      "id": "s.inner-label.required-start",
+      "parent": "s.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 17.0
+        }
+      }
+    },
+    {
+      "id": "s.inner-label.required-end",
+      "parent": "s.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 17.0
+        }
+      }
+    },
+    {
+      "id": "m",
+      "parent": null,
+      "props": {
+        "labelPlacement": {
+          "type": "value",
+          "value": "none"
+        },
+        "chipStyle": {
+          "type": "component_style",
+          "value": "embedded-chip.m.secondary"
+        },
+        "boxPaddingStart": {
+          "type": "dimension",
+          "value": 14.0
+        },
+        "boxPaddingEnd": {
+          "type": "dimension",
+          "value": 14.0
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 12.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 12.0
+        },
+        "startContentPadding": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "endContentPadding": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxMinHeight": {
+          "type": "dimension",
+          "value": 48.0
+        },
+        "alignmentMinHeight": {
+          "type": "dimension",
+          "value": 48.0
+        },
+        "startContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "endContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "valueStyle": {
+          "type": "typography",
+          "value": "body.m.normal"
+        },
+        "placeholderStyle": {
+          "type": "typography",
+          "value": "body.m.normal"
+        },
+        "fieldType": {
+          "type": "value",
+          "value": "optional"
+        }
+      }
+    },
+    {
+      "id": "m.required-start",
+      "parent": "m",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 20.0
+        }
+      }
+    },
+    {
+      "id": "m.required-end",
+      "parent": "m",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 20.0
+        }
+      }
+    },
+    {
+      "id": "m.outer-label",
+      "parent": "m",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "outer"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.m.normal"
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.m.normal"
+        }
+      }
+    },
+    {
+      "id": "m.outer-label.required-start",
+      "parent": "m.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 7.0
+        }
+      }
+    },
+    {
+      "id": "m.outer-label.required-end",
+      "parent": "m.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 4.0
+        }
+      }
+    },
+    {
+      "id": "m.inner-label",
+      "parent": "m",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "inner"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 2.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        }
+      }
+    },
+    {
+      "id": "m.inner-label.required-start",
+      "parent": "m.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 20.0
+        }
+      }
+    },
+    {
+      "id": "m.inner-label.required-end",
+      "parent": "m.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 20.0
+        }
+      }
+    },
+    {
+      "id": "l",
+      "parent": null,
+      "props": {
+        "labelPlacement": {
+          "type": "value",
+          "value": "none"
+        },
+        "chipStyle": {
+          "type": "component_style",
+          "value": "embedded-chip.l.secondary"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "startContentPadding": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "endContentPadding": {
+          "type": "dimension",
+          "value": 10.0
+        },
+        "boxMinHeight": {
+          "type": "dimension",
+          "value": 56.0
+        },
+        "alignmentMinHeight": {
+          "type": "dimension",
+          "value": 56.0
+        },
+        "startContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "endContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "valueStyle": {
+          "type": "typography",
+          "value": "body.l.normal"
+        },
+        "placeholderStyle": {
+          "type": "typography",
+          "value": "body.l.normal"
+        },
+        "fieldType": {
+          "type": "value",
+          "value": "optional"
+        }
+      }
+    },
+    {
+      "id": "l.required-start",
+      "parent": "l",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 24.0
+        }
+      }
+    },
+    {
+      "id": "l.required-end",
+      "parent": "l",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 24.0
+        }
+      }
+    },
+    {
+      "id": "l.outer-label",
+      "parent": "l",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "outer"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.l.normal"
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.l.normal"
+        }
+      }
+    },
+    {
+      "id": "l.outer-label.required-start",
+      "parent": "l.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    },
+    {
+      "id": "l.outer-label.required-end",
+      "parent": "l.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 4.0
+        }
+      }
+    },
+    {
+      "id": "l.inner-label",
+      "parent": "l",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "inner"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 2.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 9.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 9.0
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        }
+      }
+    },
+    {
+      "id": "l.inner-label.required-start",
+      "parent": "l.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 24.0
+        }
+      }
+    },
+    {
+      "id": "l.inner-label.required-end",
+      "parent": "l.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 24.0
+        }
+      }
+    }
+  ]
+}

--- a/components/sdds_serv/text_field_config.json
+++ b/components/sdds_serv/text_field_config.json
@@ -1,0 +1,1156 @@
+{
+  "view": {
+    "default": {
+      "props": {
+        "captionColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "backgroundColor": {
+          "type": "color",
+          "default": "surface.default.transparent-primary",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "surface.default.transparent-secondary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "surface.default.transparent-secondary"
+            }
+          ]
+        }
+      }
+    },
+    "success": {
+      "props": {
+        "captionColor": {
+          "type": "color",
+          "default": "text.default.positive",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        },
+        "backgroundColor": {
+          "type": "color",
+          "default": "surface.default.positive",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "surface.default.transparent-secondary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "surface.default.transparent-secondary"
+            }
+          ]
+        }
+      }
+    },
+    "warning": {
+      "props": {
+        "captionColor": {
+          "type": "color",
+          "default": "text.default.warning",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        },
+        "backgroundColor": {
+          "type": "color",
+          "default": "surface.default.warning",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "surface.default.transparent-secondary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "surface.default.transparent-secondary"
+            }
+          ]
+        }
+      }
+    },
+    "error": {
+      "props": {
+        "captionColor": {
+          "type": "color",
+          "default": "text.default.negative",
+          "states": [
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "text.default.secondary"
+            },
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "text.default.secondary"
+            }
+          ]
+        },
+        "backgroundColor": {
+          "type": "color",
+          "default": "surface.default.negative",
+          "states": [
+            {
+              "state": [
+                "pressed"
+              ],
+              "value": "surface.default.transparent-secondary"
+            },
+            {
+              "state": [
+                "focused"
+              ],
+              "value": "surface.default.transparent-secondary"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "props": {
+    "disableAlpha": 0.4,
+    "enableAlpha": 1.0,
+    "captionStyle": {
+      "type": "typography",
+      "value": "body.xs.normal"
+    },
+    "counterStyle": {
+      "type": "typography",
+      "value": "body.xs.normal"
+    },
+    "chipGroupStyle": {
+      "type": "component_style",
+      "value": "chip-group.dense"
+    },
+    "optionalPadding": {
+      "type": "dimension",
+      "value": 4.0
+    },
+    "helperTextPadding": {
+      "type": "dimension",
+      "value": 4.0
+    },
+    "chipsPadding": {
+      "type": "dimension",
+      "value": 6.0
+    },
+    "valueColor": {
+      "type": "color",
+      "default": "text.default.primary"
+    },
+    "valueColorReadOnly": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "captionColorReadOnly": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "startContentColor": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "endContentColor": {
+      "type": "color",
+      "default": "text.default.secondary",
+      "states": [
+        {
+          "state": [
+            "pressed"
+          ],
+          "value": "text.default.secondary-active"
+        },
+        {
+          "state": [
+            "hovered"
+          ],
+          "value": "text.default.secondary-hover"
+        }
+      ]
+    },
+    "optionalColor": {
+      "type": "color",
+      "default": "text.default.tertiary"
+    },
+    "counterColor": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "placeholderColor": {
+      "type": "color",
+      "default": "text.default.secondary",
+      "states": [
+        {
+          "state": [
+            "focused"
+          ],
+          "value": "text.default.tertiary"
+        },
+        {
+          "state": [
+            "pressed"
+          ],
+          "value": "text.default.tertiary"
+        }
+      ]
+    },
+    "placeholderColorReadOnly": {
+      "type": "color",
+      "default": "text.default.secondary"
+    },
+    "backgroundColorReadOnly": {
+      "type": "color",
+      "default": "surface.default.solid-default"
+    },
+    "indicatorColor": {
+      "type": "color",
+      "default": "surface.default.negative"
+    },
+    "cursorColor": {
+      "type": "color",
+      "default": "text.default.accent"
+    }
+  },
+  "variations": [
+    {
+      "id": "xs",
+      "parent": null,
+      "props": {
+        "labelPlacement": {
+          "type": "value",
+          "value": "none"
+        },
+        "shape": {
+          "type": "shape",
+          "value": "round.s",
+          "adjustment": 0
+        },
+        "chipStyle": {
+          "type": "component_style",
+          "value": "embedded-chip.xs.secondary"
+        },
+        "boxPaddingStart": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxPaddingEnd": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "startContentPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "endContentPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "boxMinHeight": {
+          "type": "dimension",
+          "value": 32.0
+        },
+        "alignmentMinHeight": {
+          "type": "dimension",
+          "value": 32.0
+        },
+        "startContentSize": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "endContentSize": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "valueStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "placeholderStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "fieldType": {
+          "type": "value",
+          "value": "optional"
+        }
+      }
+    },
+    {
+      "id": "xs.required-start",
+      "parent": "xs",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "labelPlacement": {
+          "value": "none"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        }
+      }
+    },
+    {
+      "id": "xs.required-end",
+      "parent": "xs",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        }
+      }
+    },
+    {
+      "id": "xs.outer-label",
+      "parent": "xs",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "outer"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        }
+      }
+    },
+    {
+      "id": "xs.outer-label.required-start",
+      "parent": "xs.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 0.0
+        }
+      }
+    },
+    {
+      "id": "xs.outer-label.required-end",
+      "parent": "xs.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 2.0
+        }
+      }
+    },
+    {
+      "id": "s",
+      "parent": null,
+      "props": {
+        "labelPlacement": {
+          "type": "value",
+          "value": "none"
+        },
+        "shape": {
+          "type": "shape",
+          "value": "round.m",
+          "adjustment": -2.0
+        },
+        "chipStyle": {
+          "type": "component_style",
+          "value": "embedded-chip.s.secondary"
+        },
+        "boxPaddingStart": {
+          "type": "dimension",
+          "value": 12.0
+        },
+        "boxPaddingEnd": {
+          "type": "dimension",
+          "value": 12.0
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "startContentPadding": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "endContentPadding": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "boxMinHeight": {
+          "type": "dimension",
+          "value": 40.0
+        },
+        "alignmentMinHeight": {
+          "type": "dimension",
+          "value": 40.0
+        },
+        "startContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "endContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "valueStyle": {
+          "type": "typography",
+          "value": "body.s.normal"
+        },
+        "placeholderStyle": {
+          "type": "typography",
+          "value": "body.s.normal"
+        },
+        "fieldType": {
+          "type": "value",
+          "value": "optional"
+        }
+      }
+    },
+    {
+      "id": "s.required-start",
+      "parent": "s",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        }
+      }
+    },
+    {
+      "id": "s.required-end",
+      "parent": "s",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        }
+      }
+    },
+    {
+      "id": "s.outer-label",
+      "parent": "s",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "outer"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.s.normal"
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.s.normal"
+        }
+      }
+    },
+    {
+      "id": "s.outer-label.required-start",
+      "parent": "s.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 0.0
+        }
+      }
+    },
+    {
+      "id": "s.outer-label.required-end",
+      "parent": "s.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 4.0
+        }
+      }
+    },
+    {
+      "id": "s.inner-label",
+      "parent": "s",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "inner"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 0.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        }
+      }
+    },
+    {
+      "id": "s.inner-label.required-start",
+      "parent": "s.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        }
+      }
+    },
+    {
+      "id": "s.inner-label.required-end",
+      "parent": "s.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        }
+      }
+    },
+    {
+      "id": "m",
+      "parent": null,
+      "props": {
+        "labelPlacement": {
+          "type": "value",
+          "value": "none"
+        },
+        "shape": {
+          "type": "shape",
+          "value": "round.m"
+        },
+        "chipStyle": {
+          "type": "component_style",
+          "value": "embedded-chip.m.secondary"
+        },
+        "boxPaddingStart": {
+          "type": "dimension",
+          "value": 14.0
+        },
+        "boxPaddingEnd": {
+          "type": "dimension",
+          "value": 14.0
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 12.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 12.0
+        },
+        "startContentPadding": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "endContentPadding": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "boxMinHeight": {
+          "type": "dimension",
+          "value": 48.0
+        },
+        "alignmentMinHeight": {
+          "type": "dimension",
+          "value": 48.0
+        },
+        "startContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "endContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "valueStyle": {
+          "type": "typography",
+          "value": "body.m.normal"
+        },
+        "placeholderStyle": {
+          "type": "typography",
+          "value": "body.m.normal"
+        },
+        "fieldType": {
+          "type": "value",
+          "value": "optional"
+        }
+      }
+    },
+    {
+      "id": "m.required-start",
+      "parent": "m",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    },
+    {
+      "id": "m.required-end",
+      "parent": "m",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    },
+    {
+      "id": "m.outer-label",
+      "parent": "m",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "outer"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 10.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.m.normal"
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.m.normal"
+        }
+      }
+    },
+    {
+      "id": "m.outer-label.required-start",
+      "parent": "m.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 0.0
+        }
+      }
+    },
+    {
+      "id": "m.outer-label.required-end",
+      "parent": "m.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 4.0
+        }
+      }
+    },
+    {
+      "id": "m.inner-label",
+      "parent": "m",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "inner"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 2.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        }
+      }
+    },
+    {
+      "id": "m.inner-label.required-start",
+      "parent": "m.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    },
+    {
+      "id": "m.inner-label.required-end",
+      "parent": "m.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    },
+    {
+      "id": "l",
+      "parent": null,
+      "props": {
+        "labelPlacement": {
+          "type": "value",
+          "value": "none"
+        },
+        "shape": {
+          "type": "shape",
+          "value": "round.m",
+          "adjustment": 2.0
+        },
+        "chipStyle": {
+          "type": "component_style",
+          "value": "embedded-chip.l.secondary"
+        },
+        "boxPaddingStart": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "boxPaddingEnd": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 16.0
+        },
+        "startContentPadding": {
+          "type": "dimension",
+          "value": 8.0
+        },
+        "endContentPadding": {
+          "type": "dimension",
+          "value": 10.0
+        },
+        "boxMinHeight": {
+          "type": "dimension",
+          "value": 56.0
+        },
+        "alignmentMinHeight": {
+          "type": "dimension",
+          "value": 56.0
+        },
+        "startContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "endContentSize": {
+          "type": "dimension",
+          "value": 24.0
+        },
+        "valueStyle": {
+          "type": "typography",
+          "value": "body.l.normal"
+        },
+        "placeholderStyle": {
+          "type": "typography",
+          "value": "body.l.normal"
+        },
+        "fieldType": {
+          "type": "value",
+          "value": "optional"
+        }
+      }
+    },
+    {
+      "id": "l.required-start",
+      "parent": "l",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    },
+    {
+      "id": "l.required-end",
+      "parent": "l",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    },
+    {
+      "id": "l.outer-label",
+      "parent": "l",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.primary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "outer"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 12.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.l.normal"
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.l.normal"
+        }
+      }
+    },
+    {
+      "id": "l.outer-label.required-start",
+      "parent": "l.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 0.0
+        }
+      }
+    },
+    {
+      "id": "l.outer-label.required-end",
+      "parent": "l.outer-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 6.0
+        },
+        "indicatorOffsetX": {
+          "type": "dimension",
+          "value": 4.0
+        },
+        "indicatorOffsetY": {
+          "type": "dimension",
+          "value": 4.0
+        }
+      }
+    },
+    {
+      "id": "l.inner-label",
+      "parent": "l",
+      "props": {
+        "labelColor": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelColorReadOnly": {
+          "type": "color",
+          "default": "text.default.secondary"
+        },
+        "labelPlacement": {
+          "type": "value",
+          "value": "inner"
+        },
+        "labelPadding": {
+          "type": "dimension",
+          "value": 2.0
+        },
+        "labelStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        },
+        "boxPaddingTop": {
+          "type": "dimension",
+          "value": 9.0
+        },
+        "boxPaddingBottom": {
+          "type": "dimension",
+          "value": 9.0
+        },
+        "optionalStyle": {
+          "type": "typography",
+          "value": "body.xs.normal"
+        }
+      }
+    },
+    {
+      "id": "l.inner-label.required-start",
+      "parent": "l.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredStart"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    },
+    {
+      "id": "l.inner-label.required-end",
+      "parent": "l.inner-label",
+      "props": {
+        "fieldType": {
+          "type": "value",
+          "value": "requiredEnd"
+        },
+        "indicatorSize": {
+          "type": "dimension",
+          "value": 8.0
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
* Добавил конфиги для text field, text field clear, text area, text area clear.
Вики https://github.com/salute-developers/theme-converter/wiki/Конфигурация-TextField---TextArea.

Особое внимание на:
- параметры chipGroupStyle, chipStyle - они содержат ссылки на стили чипгруппы и стили чипа.
- innerLabelStyle - сделан опциональным. Отсутствие этого параметра или null означают, что в данной вариации размера inner label не отображается.