### PR TITLE
fix: clear M start end padding were fixed

### DIFF
--- a/components/sdds_serv/text_area_clear_config.json
+++ b/components/sdds_serv/text_area_clear_config.json
@@ -879,14 +879,6 @@
           "type": "component_style",
           "value": "embedded-chip.m.secondary"
         },
-        "boxPaddingStart": {
-          "type": "dimension",
-          "value": 14.0
-        },
-        "boxPaddingEnd": {
-          "type": "dimension",
-          "value": 14.0
-        },
         "boxPaddingTop": {
           "type": "dimension",
           "value": 12.0

--- a/components/sdds_serv/text_field_clear_config.json
+++ b/components/sdds_serv/text_field_clear_config.json
@@ -879,14 +879,6 @@
           "type": "component_style",
           "value": "embedded-chip.m.secondary"
         },
-        "boxPaddingStart": {
-          "type": "dimension",
-          "value": 14.0
-        },
-        "boxPaddingEnd": {
-          "type": "dimension",
-          "value": 14.0
-        },
         "boxPaddingTop": {
           "type": "dimension",
           "value": 12.0


### PR DESCRIPTION
Убрали лишние паддинги у text field clear и text area clear в размерах M